### PR TITLE
feat: add session management for agenda

### DIFF
--- a/src/main/java/com/dnobretech/psicoapp/controller/SessionController.java
+++ b/src/main/java/com/dnobretech/psicoapp/controller/SessionController.java
@@ -1,0 +1,58 @@
+package com.dnobretech.psicoapp.controller;
+
+import com.dnobretech.psicoapp.dto.SessionRequestDTO;
+import com.dnobretech.psicoapp.dto.SessionResponseDTO;
+import com.dnobretech.psicoapp.service.SessionService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class SessionController {
+
+    @Autowired
+    private SessionService sessionService;
+
+    @GetMapping("/sessions")
+    public List<SessionResponseDTO> getAllSessions() {
+        return sessionService.findAll();
+    }
+
+    @GetMapping("/sessions/{id}")
+    public ResponseEntity<SessionResponseDTO> getSessionById(@PathVariable Long id) {
+        return sessionService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/patients/{patientId}/sessions")
+    public List<SessionResponseDTO> getSessionsByPatient(@PathVariable Long patientId) {
+        return sessionService.findByPacienteId(patientId);
+    }
+
+    @PostMapping("/sessions")
+    public ResponseEntity<SessionResponseDTO> createSession(@Valid @RequestBody SessionRequestDTO sessionRequestDTO) {
+        SessionResponseDTO saved = sessionService.save(sessionRequestDTO);
+        return ResponseEntity.status(201).body(saved);
+    }
+
+    @PutMapping("/sessions/{id}")
+    public ResponseEntity<SessionResponseDTO> updateSession(@PathVariable Long id,
+                                                            @Valid @RequestBody SessionRequestDTO sessionRequestDTO) {
+        return sessionService.update(id, sessionRequestDTO)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/sessions/{id}")
+    public ResponseEntity<Void> deleteSession(@PathVariable Long id) {
+        if (sessionService.deleteById(id)) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/dnobretech/psicoapp/dto/SessionRequestDTO.java
+++ b/src/main/java/com/dnobretech/psicoapp/dto/SessionRequestDTO.java
@@ -1,0 +1,36 @@
+package com.dnobretech.psicoapp.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionRequestDTO {
+
+    @NotNull(message = "O paciente é obrigatório.")
+    private Long pacienteId;
+
+    @NotNull(message = "A data da sessão é obrigatória.")
+    private LocalDate dataSessao;
+
+    @NotNull(message = "A hora de início é obrigatória.")
+    private LocalTime horaInicio;
+
+    private Integer duracaoMinutos;
+    private String tituloSessao;
+    private String notasAgendamento;
+    private String notasInternas;
+    private String tipoSessao;
+    private String statusSessao;
+    private BigDecimal valorSessao;
+    private String recorrencia;
+}

--- a/src/main/java/com/dnobretech/psicoapp/dto/SessionResponseDTO.java
+++ b/src/main/java/com/dnobretech/psicoapp/dto/SessionResponseDTO.java
@@ -1,0 +1,29 @@
+package com.dnobretech.psicoapp.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionResponseDTO {
+    private Long id;
+    private Long pacienteId;
+    private LocalDate dataSessao;
+    private LocalTime horaInicio;
+    private Integer duracaoMinutos;
+    private String tituloSessao;
+    private String notasAgendamento;
+    private String notasInternas;
+    private String tipoSessao;
+    private String statusSessao;
+    private BigDecimal valorSessao;
+    private String recorrencia;
+}

--- a/src/main/java/com/dnobretech/psicoapp/mapper/SessionMapper.java
+++ b/src/main/java/com/dnobretech/psicoapp/mapper/SessionMapper.java
@@ -1,0 +1,42 @@
+package com.dnobretech.psicoapp.mapper;
+
+import com.dnobretech.psicoapp.dto.SessionRequestDTO;
+import com.dnobretech.psicoapp.dto.SessionResponseDTO;
+import com.dnobretech.psicoapp.model.PacienteModel;
+import com.dnobretech.psicoapp.model.SessionModel;
+
+public class SessionMapper {
+
+    public static SessionModel toEntity(SessionRequestDTO dto, PacienteModel paciente) {
+        return SessionModel.builder()
+                .paciente(paciente)
+                .dataSessao(dto.getDataSessao())
+                .horaInicio(dto.getHoraInicio())
+                .duracaoMinutos(dto.getDuracaoMinutos())
+                .tituloSessao(dto.getTituloSessao())
+                .notasAgendamento(dto.getNotasAgendamento())
+                .notasInternas(dto.getNotasInternas())
+                .tipoSessao(dto.getTipoSessao())
+                .statusSessao(dto.getStatusSessao())
+                .valorSessao(dto.getValorSessao())
+                .recorrencia(dto.getRecorrencia())
+                .build();
+    }
+
+    public static SessionResponseDTO toResponseDTO(SessionModel session) {
+        return SessionResponseDTO.builder()
+                .id(session.getId())
+                .pacienteId(session.getPaciente().getId())
+                .dataSessao(session.getDataSessao())
+                .horaInicio(session.getHoraInicio())
+                .duracaoMinutos(session.getDuracaoMinutos())
+                .tituloSessao(session.getTituloSessao())
+                .notasAgendamento(session.getNotasAgendamento())
+                .notasInternas(session.getNotasInternas())
+                .tipoSessao(session.getTipoSessao())
+                .statusSessao(session.getStatusSessao())
+                .valorSessao(session.getValorSessao())
+                .recorrencia(session.getRecorrencia())
+                .build();
+    }
+}

--- a/src/main/java/com/dnobretech/psicoapp/model/SessionModel.java
+++ b/src/main/java/com/dnobretech/psicoapp/model/SessionModel.java
@@ -1,0 +1,58 @@
+package com.dnobretech.psicoapp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "sessions")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SessionModel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private PacienteModel paciente;
+
+    @Column(name = "data_sessao", nullable = false)
+    private LocalDate dataSessao;
+
+    @Column(name = "hora_inicio", nullable = false)
+    private LocalTime horaInicio;
+
+    @Column(name = "duracao_minutos")
+    private Integer duracaoMinutos;
+
+    @Column(name = "titulo_sessao")
+    private String tituloSessao;
+
+    @Column(name = "notas_agendamento", columnDefinition = "TEXT")
+    private String notasAgendamento;
+
+    @Column(name = "notas_internas", columnDefinition = "TEXT")
+    private String notasInternas;
+
+    @Column(name = "tipo_sessao")
+    private String tipoSessao;
+
+    @Column(name = "status_sessao")
+    private String statusSessao;
+
+    @Column(name = "valor_sessao")
+    private BigDecimal valorSessao;
+
+    @Column(name = "recorrencia")
+    private String recorrencia;
+}

--- a/src/main/java/com/dnobretech/psicoapp/repository/SessionRepository.java
+++ b/src/main/java/com/dnobretech/psicoapp/repository/SessionRepository.java
@@ -1,0 +1,12 @@
+package com.dnobretech.psicoapp.repository;
+
+import com.dnobretech.psicoapp.model.SessionModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SessionRepository extends JpaRepository<SessionModel, Long> {
+    List<SessionModel> findByPacienteId(Long pacienteId);
+}

--- a/src/main/java/com/dnobretech/psicoapp/service/SessionService.java
+++ b/src/main/java/com/dnobretech/psicoapp/service/SessionService.java
@@ -1,0 +1,16 @@
+package com.dnobretech.psicoapp.service;
+
+import com.dnobretech.psicoapp.dto.SessionRequestDTO;
+import com.dnobretech.psicoapp.dto.SessionResponseDTO;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SessionService {
+    List<SessionResponseDTO> findAll();
+    Optional<SessionResponseDTO> findById(Long id);
+    List<SessionResponseDTO> findByPacienteId(Long pacienteId);
+    SessionResponseDTO save(SessionRequestDTO sessionRequestDTO);
+    Optional<SessionResponseDTO> update(Long id, SessionRequestDTO sessionRequestDTO);
+    boolean deleteById(Long id);
+}

--- a/src/main/java/com/dnobretech/psicoapp/service/impl/SessionServiceImpl.java
+++ b/src/main/java/com/dnobretech/psicoapp/service/impl/SessionServiceImpl.java
@@ -1,0 +1,75 @@
+package com.dnobretech.psicoapp.service.impl;
+
+import com.dnobretech.psicoapp.dto.SessionRequestDTO;
+import com.dnobretech.psicoapp.dto.SessionResponseDTO;
+import com.dnobretech.psicoapp.mapper.SessionMapper;
+import com.dnobretech.psicoapp.model.PacienteModel;
+import com.dnobretech.psicoapp.model.SessionModel;
+import com.dnobretech.psicoapp.repository.PacienteRepository;
+import com.dnobretech.psicoapp.repository.SessionRepository;
+import com.dnobretech.psicoapp.service.SessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class SessionServiceImpl implements SessionService {
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Autowired
+    private PacienteRepository pacienteRepository;
+
+    @Override
+    public List<SessionResponseDTO> findAll() {
+        return sessionRepository.findAll().stream()
+                .map(SessionMapper::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<SessionResponseDTO> findById(Long id) {
+        return sessionRepository.findById(id).map(SessionMapper::toResponseDTO);
+    }
+
+    @Override
+    public List<SessionResponseDTO> findByPacienteId(Long pacienteId) {
+        return sessionRepository.findByPacienteId(pacienteId).stream()
+                .map(SessionMapper::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public SessionResponseDTO save(SessionRequestDTO sessionRequestDTO) {
+        PacienteModel paciente = pacienteRepository.findById(sessionRequestDTO.getPacienteId())
+                .orElseThrow(() -> new RuntimeException("Paciente não encontrado"));
+        SessionModel session = SessionMapper.toEntity(sessionRequestDTO, paciente);
+        SessionModel saved = sessionRepository.save(session);
+        return SessionMapper.toResponseDTO(saved);
+    }
+
+    @Override
+    public Optional<SessionResponseDTO> update(Long id, SessionRequestDTO sessionRequestDTO) {
+        return sessionRepository.findById(id).map(existing -> {
+            PacienteModel paciente = pacienteRepository.findById(sessionRequestDTO.getPacienteId())
+                    .orElseThrow(() -> new RuntimeException("Paciente não encontrado"));
+            SessionModel updated = SessionMapper.toEntity(sessionRequestDTO, paciente);
+            updated.setId(existing.getId());
+            SessionModel saved = sessionRepository.save(updated);
+            return SessionMapper.toResponseDTO(saved);
+        });
+    }
+
+    @Override
+    public boolean deleteById(Long id) {
+        if (sessionRepository.existsById(id)) {
+            sessionRepository.deleteById(id);
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add JPA model and DTOs for agenda sessions
- create repository, service and mapper for sessions
- expose CRUD and patient-specific session endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f656a50e8832f9529a19c9faa8b52