### PR TITLE
feat: add patient pagination

### DIFF
--- a/src/main/java/com/dnobretech/psicoapp/controller/PacienteController.java
+++ b/src/main/java/com/dnobretech/psicoapp/controller/PacienteController.java
@@ -5,10 +5,11 @@ import com.dnobretech.psicoapp.dto.PacienteResponseDTO;
 import com.dnobretech.psicoapp.service.PacienteService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/patients")
@@ -18,8 +19,9 @@ public class PacienteController {
     private PacienteService pacienteService; // Agora depende do Serviço, não do Repositório!
 
     @GetMapping
-    public List<PacienteResponseDTO> getAllPacientes() {
-        return pacienteService.findAll();
+    public Page<PacienteResponseDTO> getAllPacientes(
+            @PageableDefault(size = 10) Pageable pageable) {
+        return pacienteService.findAll(pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/dnobretech/psicoapp/service/PacienteService.java
+++ b/src/main/java/com/dnobretech/psicoapp/service/PacienteService.java
@@ -3,11 +3,12 @@ package com.dnobretech.psicoapp.service;
 import com.dnobretech.psicoapp.dto.PacienteRequestDTO;
 import com.dnobretech.psicoapp.dto.PacienteResponseDTO;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
 public interface PacienteService {
-    List<PacienteResponseDTO> findAll();
+    Page<PacienteResponseDTO> findAll(Pageable pageable);
     Optional<PacienteResponseDTO> findById(Long id);
     PacienteResponseDTO save(PacienteRequestDTO pacienteRequestDTO);
     Optional<PacienteResponseDTO> update(Long id, PacienteRequestDTO pacienteRequestDTO);

--- a/src/main/java/com/dnobretech/psicoapp/service/impl/PacienteServiceImpl.java
+++ b/src/main/java/com/dnobretech/psicoapp/service/impl/PacienteServiceImpl.java
@@ -7,11 +7,11 @@ import com.dnobretech.psicoapp.model.PacienteModel;
 import com.dnobretech.psicoapp.repository.PacienteRepository;
 import com.dnobretech.psicoapp.service.PacienteService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service // Marca a classe como um componente de serviço (lógica de negócio)
 public class PacienteServiceImpl implements PacienteService {
@@ -20,11 +20,9 @@ public class PacienteServiceImpl implements PacienteService {
     private PacienteRepository pacienteRepository;
 
     @Override
-    public List<PacienteResponseDTO> findAll() {
-        return pacienteRepository.findAll()
-                .stream()
-                .map(PacienteMapper::toResponseDTO)
-                .collect(Collectors.toList());
+    public Page<PacienteResponseDTO> findAll(Pageable pageable) {
+        return pacienteRepository.findAll(pageable)
+                .map(PacienteMapper::toResponseDTO);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add page & size params to patient listing endpoint
- implement pageable patient service using Spring Data Page
- use Spring's `Pageable` abstraction for pagination

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f89968304832f9721a84d080f253e