### PR TITLE
feat: add recurrence and payment fields to sessions

### DIFF
--- a/src/main/java/com/dnobretech/psicoapp/dto/SessionRequestDTO.java
+++ b/src/main/java/com/dnobretech/psicoapp/dto/SessionRequestDTO.java
@@ -33,4 +33,8 @@ public class SessionRequestDTO {
     private String statusSessao;
     private BigDecimal valorSessao;
     private String recorrencia;
+    private LocalDate recorrenciaDataFim;
+    private String statusPagamento;
+    private LocalDate dataRecebimento;
+    private String formaRecebimento;
 }

--- a/src/main/java/com/dnobretech/psicoapp/dto/SessionResponseDTO.java
+++ b/src/main/java/com/dnobretech/psicoapp/dto/SessionResponseDTO.java
@@ -26,4 +26,8 @@ public class SessionResponseDTO {
     private String statusSessao;
     private BigDecimal valorSessao;
     private String recorrencia;
+    private LocalDate recorrenciaDataFim;
+    private String statusPagamento;
+    private LocalDate dataRecebimento;
+    private String formaRecebimento;
 }

--- a/src/main/java/com/dnobretech/psicoapp/mapper/SessionMapper.java
+++ b/src/main/java/com/dnobretech/psicoapp/mapper/SessionMapper.java
@@ -20,6 +20,10 @@ public class SessionMapper {
                 .statusSessao(dto.getStatusSessao())
                 .valorSessao(dto.getValorSessao())
                 .recorrencia(dto.getRecorrencia())
+                .recorrenciaDataFim(dto.getRecorrenciaDataFim())
+                .statusPagamento(dto.getStatusPagamento())
+                .dataRecebimento(dto.getDataRecebimento())
+                .formaRecebimento(dto.getFormaRecebimento())
                 .build();
     }
 
@@ -37,6 +41,10 @@ public class SessionMapper {
                 .statusSessao(session.getStatusSessao())
                 .valorSessao(session.getValorSessao())
                 .recorrencia(session.getRecorrencia())
+                .recorrenciaDataFim(session.getRecorrenciaDataFim())
+                .statusPagamento(session.getStatusPagamento())
+                .dataRecebimento(session.getDataRecebimento())
+                .formaRecebimento(session.getFormaRecebimento())
                 .build();
     }
 }

--- a/src/main/java/com/dnobretech/psicoapp/model/SessionModel.java
+++ b/src/main/java/com/dnobretech/psicoapp/model/SessionModel.java
@@ -55,4 +55,16 @@ public class SessionModel {
 
     @Column(name = "recorrencia")
     private String recorrencia;
+
+    @Column(name = "recorrencia_data_fim")
+    private LocalDate recorrenciaDataFim;
+
+    @Column(name = "status_pagamento")
+    private String statusPagamento;
+
+    @Column(name = "data_recebimento")
+    private LocalDate dataRecebimento;
+
+    @Column(name = "forma_recebimento")
+    private String formaRecebimento;
 }


### PR DESCRIPTION
## Summary
- support recurrence end date and payment details in session entity
- expose new fields through request/response DTOs
- map recurrence and payment data between DTOs and entity

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689f9039cee8832fb1b99db2f0c7e5b7